### PR TITLE
Switch from argDetails to Arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,11 +28,11 @@ class Help {
     const visibleCommands = cmd.commands.filter(cmd => !cmd._hidden);
     if (cmd._hasImplicitHelpCommand()) {
       // Create a command matching the implicit help command.
-      const pieces = cmd._helpCommandnameAndArgs.split(/ +/);
-      const helpCommand = cmd.createCommand(pieces.shift())
+      const [, helpName, helpArgs] = cmd._helpCommandnameAndArgs.match(/([^ ]+) *(.*)/);
+      const helpCommand = cmd.createCommand(helpName)
         .helpOption(false);
       helpCommand.description(cmd._helpCommandDescription);
-      if (pieces.length > 0) helpCommand.arguments(pieces.join(' '));
+      if (helpArgs) helpCommand.arguments(helpArgs);
       visibleCommands.push(helpCommand);
     }
     if (this.sortSubcommands) {
@@ -650,8 +650,8 @@ class Command extends EventEmitter {
       desc = null;
     }
     opts = opts || {};
-    const args = nameAndArgs.split(/ +/);
-    const cmd = this.createCommand(args.shift());
+    const [, name, args] = nameAndArgs.match(/([^ ]+) *(.*)/);
+    const cmd = this.createCommand(name);
 
     if (desc) {
       cmd.description(desc);
@@ -678,8 +678,8 @@ class Command extends EventEmitter {
     cmd._enablePositionalOptions = this._enablePositionalOptions;
 
     cmd._executableFile = opts.executableFile || null; // Custom name for executable file, set missing to null to match constructor
+    if (args) cmd.arguments(args);
     this.commands.push(cmd);
-    if (args.length > 0) cmd.arguments(args.join(' '));
     cmd.parent = this;
 
     if (desc) return this;

--- a/index.js
+++ b/index.js
@@ -86,11 +86,15 @@ class Help {
    */
 
   visibleArguments(cmd) {
-    if (cmd._argsDescription && cmd._args.length) {
-      return cmd._args.map((argument) => {
-        return { term: argument.name, description: cmd._argsDescription[argument.name] || '' };
-      }, 0);
-    }
+    // If there are some argument description then return all the arguments.
+    if (cmd._argsDescription || cmd._args.find(argument => argument.description)) {
+      const legacyDescriptions = cmd._argsDescription || {};
+      return cmd._args.map(argument => {
+        const term = argument.name;
+        const description = argument.description || legacyDescriptions[argument.name] || '';
+        return { term, description };
+      });
+    };
     return [];
   }
 
@@ -586,7 +590,7 @@ class Command extends EventEmitter {
     this._aliases = [];
     this._combineFlagAndOptionalValue = true;
     this._description = '';
-    this._argsDescription = undefined;
+    this._argsDescription = undefined; // legacy
     this._enablePositionalOptions = false;
     this._passThroughOptions = false;
 
@@ -802,17 +806,7 @@ class Command extends EventEmitter {
     if (previousArgument && previousArgument.variadic) {
       throw new Error(`only the last argument can be variadic '${previousArgument.name}'`);
     }
-
     this._args.push(argument);
-
-    // Legacy description handling
-    if (argument.description) {
-      if (!this._argsDescription) {
-        this._argsDescription = {};
-      }
-      this._argsDescription[argument.name] = argument.description;
-    }
-
     return this;
   }
 

--- a/tests/args.badArg.test.js
+++ b/tests/args.badArg.test.js
@@ -2,6 +2,6 @@ const commander = require('../');
 
 test('should throw on bad argument', () => {
   const program = new commander.Command();
-  expect(() => program.addArgument(new commander.Argument('bad name'))).toThrowError('Bad argument format: bad name');
-  expect(() => program.argument(new commander.Argument('bad name'))).toThrowError('Bad argument format: bad name');
+  expect(() => program.addArgument(new commander.Argument('bad-format'))).toThrow();
+  expect(() => program.argument('bad-format')).toThrow();
 });

--- a/tests/command.action.test.js
+++ b/tests/command.action.test.js
@@ -23,14 +23,14 @@ test('when .action called then program.args only contains args', () => {
   expect(program.args).toEqual(['info', 'my-file']);
 });
 
-test.each(getTestCases('<file>'))('when .action on program with required argument and argument supplied then action called', (program) => {
+test.each(getTestCases('<file>'))('when .action on program with required argument via %s and argument supplied then action called', (methodName, program) => {
   const actionMock = jest.fn();
   program.action(actionMock);
   program.parse(['node', 'test', 'my-file']);
   expect(actionMock).toHaveBeenCalledWith('my-file', program.opts(), program);
 });
 
-test.each(getTestCases('<file>'))('when .action on program with required argument and argument not supplied then action not called', (program) => {
+test.each(getTestCases('<file>'))('when .action on program with required argument via %s and argument not supplied then action not called', (methodName, program) => {
   const actionMock = jest.fn();
   program
     .exitOverride()
@@ -52,21 +52,21 @@ test('when .action on program and no arguments then action called', () => {
   expect(actionMock).toHaveBeenCalledWith(program.opts(), program);
 });
 
-test.each(getTestCases('[file]'))('when .action on program with optional argument supplied then action called', (program) => {
+test.each(getTestCases('[file]'))('when .action on program with optional argument via %s supplied then action called', (methodName, program) => {
   const actionMock = jest.fn();
   program.action(actionMock);
   program.parse(['node', 'test', 'my-file']);
   expect(actionMock).toHaveBeenCalledWith('my-file', program.opts(), program);
 });
 
-test.each(getTestCases('[file]'))('when .action on program without optional argument supplied then action called', (program) => {
+test.each(getTestCases('[file]'))('when .action on program without optional argument supplied then action called', (methodName, program) => {
   const actionMock = jest.fn();
   program.action(actionMock);
   program.parse(['node', 'test']);
   expect(actionMock).toHaveBeenCalledWith(undefined, program.opts(), program);
 });
 
-test.each(getTestCases('[file]'))('when .action on program with optional argument and subcommand and program argument then program action called', (program) => {
+test.each(getTestCases('[file]'))('when .action on program with optional argument via %s and subcommand and program argument then program action called', (methodName, program) => {
   const actionMock = jest.fn();
   program.action(actionMock);
   program
@@ -78,7 +78,7 @@ test.each(getTestCases('[file]'))('when .action on program with optional argumen
 });
 
 // Changes made in #1062 to allow this case
-test.each(getTestCases('[file]'))('when .action on program with optional argument and subcommand and no program argument then program action called', (program) => {
+test.each(getTestCases('[file]'))('when .action on program with optional argument via %s and subcommand and no program argument then program action called', (methodName, program) => {
   const actionMock = jest.fn();
   program.action(actionMock);
   program.command('subcommand');
@@ -108,5 +108,5 @@ function getTestCases(arg) {
   const withArguments = new commander.Command().arguments(arg);
   const withArgument = new commander.Command().argument(arg);
   const withAddArgument = new commander.Command().addArgument(new commander.Argument(arg));
-  return [withArguments, withArgument, withAddArgument];
+  return [['.arguments', withArguments], ['.argument', withArgument], ['.addArgument', withAddArgument]];
 }

--- a/tests/help.visibleCommands.test.js
+++ b/tests/help.visibleCommands.test.js
@@ -23,9 +23,9 @@ describe('visibleCommands', () => {
     const program = new commander.Command();
     program
       .command('visible', 'desc')
-      .command('invisible executable', 'desc', { hidden: true });
+      .command('invisible-executable', 'desc', { hidden: true });
     program
-      .command('invisible action', { hidden: true });
+      .command('invisible-action', { hidden: true });
     const helper = new commander.Help();
     const visibleCommandNames = helper.visibleCommands(program).map(cmd => cmd.name());
     expect(visibleCommandNames).toEqual(['visible', 'help']);


### PR DESCRIPTION
Switch from argDetails to Arguments for _args, and roll the parsing and validating into existing routines.

https://github.com/tj/commander.js/pull/1467#issuecomment-797863960

Not finished polishing the refactor yet, but feel free to merge it if you want to work on it.